### PR TITLE
Add tally support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/v3-sdk": "^3.3.2",
     "bignumber.js": "^9.0.1",
-    "bnc-onboard": "^1.25.0",
+    "bnc-onboard": "^1.36.0",
     "brightid_sdk": "^1.0.1",
     "date-fns": "^2.21.3",
     "ethers": "^5.1.4",

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -150,7 +150,6 @@ export const WalletContext: React.FC<WalletContextProps> = ({ children }) => {
               walletName: 'walletConnect',
               infuraKey: infuraApiKey,
             },
-
             {
               walletName: 'ledger',
               rpcUrl: `${hwRpcUrl}`,

--- a/src/contexts/wallet.tsx
+++ b/src/contexts/wallet.tsx
@@ -145,10 +145,12 @@ export const WalletContext: React.FC<WalletContextProps> = ({ children }) => {
           wallets: [
             { walletName: 'metamask' },
             { walletName: 'coinbase' },
+            { walletName: 'tally' },
             {
               walletName: 'walletConnect',
               infuraKey: infuraApiKey,
             },
+
             {
               walletName: 'ledger',
               rpcUrl: `${hwRpcUrl}`,


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.
